### PR TITLE
Some tasks and categories fixes

### DIFF
--- a/LMS.Admin.Web/Controllers/TaskControllers.cs
+++ b/LMS.Admin.Web/Controllers/TaskControllers.cs
@@ -83,7 +83,7 @@ namespace LMS.Admin.Web.Controllers
         [Authorize(Roles = "admin, moderator")]
         public async Task<IActionResult> Delete(int id)
         {
-            await taskService.MarkAsDeletedByIdAsync(id);
+            await taskService.DeleteByIdAsync(id);
             return RedirectToAction(nameof(List));
         }
 

--- a/LMS.Admin.Web/Views/Task/FormFields.cshtml
+++ b/LMS.Admin.Web/Views/Task/FormFields.cshtml
@@ -40,9 +40,6 @@
     <input type="number" min="0" class="form-control" onchange="displayTable(this)" value="@(Model?.AnswerOptions?.Count ?? 0)" />
 </div>
 
-<div class="form-group">
-    <input type="submit" value="Save" class="btn btn-default" />
-</div>
 <div id="tableThead" class="form-group @(Model?.Type?.Id == (int)TaskTypes.OptionQuestion ? "" : "collapse")">
     <table class="table table-bordered">
         <thead>
@@ -55,6 +52,9 @@
     </table>
 </div>
 
+<div class="form-group">
+    <input type="submit" value="Save" class="btn btn-default" />
+</div>
 <script>
     function optionCheck(select) {
         var selected = $(select).find("option:selected").val();
@@ -109,6 +109,5 @@
                 tr.appendTo("#tableBody");
             }
         });
-        alert(Array[0]["id"]);
     </script>
 }

--- a/LMS.Admin.Web/Views/Task/FormFields.cshtml
+++ b/LMS.Admin.Web/Views/Task/FormFields.cshtml
@@ -13,7 +13,10 @@
 <div class="row">
     <div class="form-group col-12 col-md-6">
         <label asp-for="Complexity" class="control-label"></label>
-        <input asp-for="Complexity" class="form-control form-control-range" type="range" min="@TaskDTO.MinComplexity" max="@TaskDTO.MaxComplexity" />
+        <label id="taskComplexity">@Model.Complexity</label>
+        <label>/ @TaskDTO.MaxComplexity</label>
+        <br />
+        <input onchange="$('#taskComplexity').text($(this).val())" style="width: 100%" asp-for="Complexity" data-slider-value="@Model.Complexity" class="form-control form-control-range" type="text" data-provide="slider" data-slider-min="@TaskDTO.MinComplexity" data-slider-max="@TaskDTO.MaxComplexity" />
         <span asp-validation-for="Complexity" class="text-danger"></span>
     </div>
     <div class="form-group col-12 col-md-6">

--- a/LMS.Admin.Web/Views/Task/FormFields.cshtml
+++ b/LMS.Admin.Web/Views/Task/FormFields.cshtml
@@ -10,6 +10,7 @@
 
 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 <input asp-for="Id" type="hidden" />
+<input asp-for="IsActive" type="hidden" />
 <div class="row">
     <div class="form-group col-12 col-md-6">
         <label asp-for="Complexity" class="control-label"></label>

--- a/LMS.Bootstrap/Mapping/OrganizationProfile.cs
+++ b/LMS.Bootstrap/Mapping/OrganizationProfile.cs
@@ -70,8 +70,8 @@ namespace LMS.Bootstrap.Mapping
                 .ForMember(m => m.Categories, m => m.ResolveUsing(entity =>
                     entity.Levels
                       .SelectMany(l => l.Categories)
-                      .Distinct()
-                      .Select(c => c.Category.Title)
+                      .GroupBy(l => l.CategoryId)
+                      .Select(l => l.First().Category.Title)
                       .ToList()))
                 .ForMember(m => m.Levels, m => m.Ignore());
 

--- a/LMS.Business/Services/TaskService.cs
+++ b/LMS.Business/Services/TaskService.cs
@@ -14,9 +14,15 @@ namespace LMS.Business.Services
         {
         }
 
-        public Task MarkAsDeletedByIdAsync(int taskId)
+        public Task DeleteByIdAsync(int taskId)
         {
-            if (unitOfWork.Tasks.Get(taskId) is Entities.Task task)
+            if (unitOfWork.Answers.Find(a => a.TaskId == taskId) == null)
+            {
+                unitOfWork.Tasks.Delete(taskId);
+
+                return unitOfWork.SaveAsync();
+            }
+            else if (unitOfWork.Tasks.Get(taskId) is Entities.Task task)
             {
                 task.IsActive = false;
 
@@ -65,7 +71,12 @@ namespace LMS.Business.Services
 
             var newTask = mapper.Map<TaskDTO, Entities.Task>(taskDto);
 
-            if (unitOfWork.Tasks.Get(newTask.Id) is Entities.Task oldTask)
+            if (unitOfWork.Answers.Find(a => a.TaskId == newTask.Id) == null)
+            {
+                unitOfWork.Tasks.Update(newTask);
+                return unitOfWork.SaveAsync();
+            }
+            else if (unitOfWork.Tasks.Get(newTask.Id) is Entities.Task oldTask)
             {
                 if (oldTask.Content == newTask.Content
                     && oldTask.Complexity == newTask.Complexity

--- a/LMS.Business/Services/TaskService.cs
+++ b/LMS.Business/Services/TaskService.cs
@@ -71,7 +71,7 @@ namespace LMS.Business.Services
                     && oldTask.Complexity == newTask.Complexity
                     && oldTask.CategoryId == newTask.CategoryId
                     && oldTask.TypeId == newTask.TypeId
-                    && oldTask.AnswerOptions.Equals(newTask.AnswerOptions))
+                    && oldTask.AnswerOptions.SequenceEqual(newTask.AnswerOptions))
                 {
                     return Task.CompletedTask;
                 }

--- a/LMS.Test/Services/CategoryServiceTests.cs
+++ b/LMS.Test/Services/CategoryServiceTests.cs
@@ -40,13 +40,12 @@ namespace LMS.Test.Services
 
             var categories = service.GetAll().ToArray();
 
-            
             Assert.Equal(3, categories[0].TasksCount);
             repositoryMock.Verify(m => m.GetAll());
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task Should_Delete()
+        public async Task Should_Delete()
         {
             var categoryForDelete = new Entities.Category
             {
@@ -70,7 +69,7 @@ namespace LMS.Test.Services
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task Should_Update()
+        public async Task Should_Update()
         {
             var oldCategory = new Entities.Category
             {
@@ -96,34 +95,9 @@ namespace LMS.Test.Services
             t.Title == newCategoryDto.Title && (t.ParentCategoryId == newCategoryDto.ParentCategoryId))));
             unitOfWorkMock.Verify(m => m.SaveAsync());
         }
-
+        
         [Fact]
-        public async System.Threading.Tasks.Task Should_Create_If_New_On_Update()
-        {
-
-            var newCategory = new Entities.Category
-            {
-                Id = 1,
-                Title = "MyCategory"
-            };
-            var newCategoryDto = mapper.Map<Entities.Category, CategoryDTO>(newCategory);
-
-            var repositoryMock = new Mock<IRepository<Entities.Category>>();
-            repositoryMock.Setup(u => u.Get(1)).Returns((Entities.Category)null);
-
-            var unitOfWorkMock = new Mock<IUnitOfWork>();
-            unitOfWorkMock.Setup(u => u.Categories).Returns(() => repositoryMock.Object);
-
-            var service = new CategoryService(unitOfWorkMock.Object, mapper);
-
-            await service.UpdateAsync(newCategoryDto);
-
-            repositoryMock.Verify(m => m.Create(It.Is<Entities.Category>(dto => dto.Title == newCategory.Title)));
-            unitOfWorkMock.Verify(m => m.SaveAsync());
-        }
-
-        [Fact]
-        public async System.Threading.Tasks.Task Should_Create_New_Item()
+        public async Task Should_Create_New_Item()
         {
             var newCategory = new CategoryDTO
             {


### PR DESCRIPTION
1. Обновлен слайдер на странице создания/редактирования задачи
2. Исправлен баг с повторением категорий в списке шаблонов
3. Вместо сравнения SequenceEquals использовался Equals для множеств ответов на задачу, когда нужно было проверить, были ли изменения - на этом падал один тест
4. В CategoryService.UpdateAsync никогда не вызывался CreateAsync в случае, когда попытка обновить несуществующую сущность - на этом падал еще один тест. Тест и CreateAsync убраны.
5. TaskService.DeleteAsync и UpdateAsync должны учитывать, была ли использована задача в ответах. Если нет - ее можно удалять/обновлять напрямую.